### PR TITLE
Fix hivemq-extension-sdk

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "hivemq-extension-sdk"]
+	path = hivemq-extension-sdk
+	url = https://github.com/hivemq/hivemq-extension-sdk


### PR DESCRIPTION
Fixes #7 
The sub module wasn't imported correctly. Docker would complain when cloning the repo. 

## Proposed Changes
 - Add sub module again with the right command. 
 - 
